### PR TITLE
Change package name to gi-gobject

### DIFF
--- a/gi-gobject.opam
+++ b/gi-gobject.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "gobject"
+name: "gi-gobject"
 version: "~unknown"
 maintainer: "Manas Jayanth<prometheansacrifice@gmail.com>"
 authors: "Manas Jayanth <prometheansacrifice@gmail.com>"

--- a/lib/dune
+++ b/lib/dune
@@ -20,7 +20,7 @@
 
 (library
  (name        GObject)
-  (public_name gobject)
+  (public_name gi-gobject)
   (libraries ctypes ctypes.foreign gi-glib2)
   (c_names         dyn_load_constants_stubs)
   (c_flags         (:include c_flags.sexp))


### PR DESCRIPTION
I added the `gi-` prefix for the GLib2 package because user can directly see that it is generated with gobject-introspection. I changed the name of the package for the sake of consistency. This is not mandatory. The decision is yours. :)